### PR TITLE
Change username prompt to match GitHub's requirements

### DIFF
--- a/lib/pullrequest.js
+++ b/lib/pullrequest.js
@@ -61,8 +61,8 @@ module.exports = function(config){
       properties: {
         username: {
           description: 'Github Username',
-          pattern: /^[a-zA-Z\s\-]+$/,
-          message: 'Name must be only letters, spaces, or dashes',
+          pattern: /^[a-zA-Z0-9][a-zA-Z0-9\-]*$/,
+          message: 'Username may only contain alphanumeric characters or dashes and cannot begin with a dash',
           required: true
         },
         password: {


### PR DESCRIPTION
Currently contribflow doesn't allow valid GitHub usernames containing numbers.
Also, it allows invalid usernames containing spaces or starting with dashes.

For usernames at GitHub the requirement is,
"Username may only contain alphanumeric characters or dashes and cannot begin
with a dash"

This changes the prompt when creating a pull request to match those
requirements.
